### PR TITLE
Modify tpm connector instance name

### DIFF
--- a/mihawk.xml
+++ b/mihawk.xml
@@ -10853,28 +10853,28 @@
     </property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/motherboard-0/tpm-connector-2</id>
+	<id>/sys-0/node-0/motherboard-0/tpmconnector-2</id>
 	<property>
 	<id>CONNECTOR_TYPE</id>
 	<value></value>
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/motherboard-0/tpm-connector-2/daughtercard-1</id>
+	<id>/sys-0/node-0/motherboard-0/tpmconnector-2/daughtercard-1</id>
 	<property>
 	<id>FRU_ID</id>
 	<value>38</value>
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/motherboard-0/tpm-connector-2/daughtercard-1/tpm-0</id>
+	<id>/sys-0/node-0/motherboard-0/tpmconnector-2/daughtercard-1/tpm-0</id>
 	<property>
 	<id>FRU_ID</id>
 	<value>37</value>
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/motherboard-0/tpm-connector-2/daughtercard-1/tpm-0/tpm.i2c-0</id>
+	<id>/sys-0/node-0/motherboard-0/tpmconnector-2/daughtercard-1/tpm-0/tpm.i2c-0</id>
 	<property>
 	<id>DIRECTION</id>
 	<value></value>
@@ -13000,7 +13000,7 @@
 	<child_id>nvlink-0</child_id>
 	<child_id>nvlink-1</child_id>
 	<child_id>planar_vpd-0</child_id>
-	<child_id>tpm-connector-2</child_id>
+	<child_id>tpmconnector-2</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -126096,10 +126096,10 @@
 	</attribute>
 </targetInstance>
 <targetInstance>
-	<id>tpm-connector-2</id>
+	<id>tpmconnector-2</id>
 	<type>connector-card-generic</type>
 	<is_root>false</is_root>
-	<instance_name>tpm-connector</instance_name>
+	<instance_name>tpmconnector</instance_name>
 	<position>2</position>
 	<child_id>daughtercard-1</child_id>
 	<attribute>


### PR DESCRIPTION
Change tpm connector instance name from tpm-connector to tpmconnector to prevent from wrong inastance name in bmc yaml file

Signed-off-by: Joy Chu <joy_chu@wistron.com>